### PR TITLE
Feature/additional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,33 +48,33 @@ Recommended role is geerlingguy.java
 
 	---
 	- hosts: apps_akhq
-	  become: yes
-	  become_method: sudo
-	  gather_facts: yes
-	  roles:
-	    - role: ansible-apps_akhq
+      become: yes
+      become_method: sudo
+      gather_facts: yes
+      roles:
+        - role: ansible-apps_akhq
       vars:
-	  	# enable SSL
-		akhq_listener_ssl: true
-		akhq_listener_ssl_self_signed: true
-		akhq_admin_passwd: myAdminPwd
-		akhq_reader_passwd: myReaderPwd
+      	# enable SSL
+    	akhq_listener_ssl: true
+    	akhq_listener_ssl_self_signed: true
+    	akhq_admin_passwd: myAdminPwd
+    	akhq_reader_passwd: myReaderPwd
         suffix: ':9092'
         kafka_bootstrap_servers:
           - name: kafka_cluster
             servers: "{{ groups['kafka_cluster'] | product([suffix]) | map('join') | join(',') }}"
-			custom_properties:
-			  # Connect to an mTLS-secured cluster
-			  security.protocol: SSL
-			  ssl.truststore.location: /var/ssl/private/truststore.jks
-			  ssl.truststore.password: trustStorePwd
-			  ssl.keystore.location: /var/ssl/private/keystore.jks
-			  ssl.keystore.password: keyStorePwd
-			  ssl.key.password: keyStorePwd
-	  environment: 
-	    http_proxy: "{{ http_proxy }}"
-	    https_proxy: "{{ https_proxy }}"
-	    no_proxy: "{{ no_proxy }}"
+            custom_properties:
+              # Connect to an mTLS-secured cluster
+              security.protocol: SSL
+              ssl.truststore.location: /var/ssl/private/truststore.jks
+              ssl.truststore.password: trustStorePwd
+              ssl.keystore.location: /var/ssl/private/keystore.jks
+              ssl.keystore.password: keyStorePwd
+              ssl.key.password: keyStorePwd
+      environment: 
+        http_proxy: "{{ http_proxy }}"
+        https_proxy: "{{ https_proxy }}"
+        no_proxy: "{{ no_proxy }}"
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Deploy [akhq](https://github.com/tchiotludo/akhq) kafka admin system using ansib
 ## Dependencies
 
 You need to install java
-Recommanded role is geerlingguy.java
+Recommended role is geerlingguy.java
 
 ## Role variables
 
@@ -28,13 +28,21 @@ Recommanded role is geerlingguy.java
 | ------------------------- | ---------------- | -----------------------------------|
 | `akhq_version`            | 0.15.0           | akhq version |
 | `akhq_install_dir`        | /opt/akhq        | Installation path for jar file |
-| `akhq_admin_passwd`       | "securepassword" | admin password to access akhq |
+| `akhq_config_dir`         | /etc/akhq        | Configuration path for application |
+| `akhq_jar_file`           | akhq.jar         | Name of the jar file |
+| `akhq_admin_passwd`       | "securepasswd"   | admin password to access akhq |
+| `akhq_reader_passwd`      | "readpasswd"     | read-only password to access akhq |
 | `akhq_ldap_server`        | ""               | ldap server |
 | `akhq_ldap_bindn`         | ""               | ldap user bindn |
 | `akhq_ldap_bindpwd`       | ""               | ldap user passwd |
 | `akhq_ldap_search_base`   | ""               | ldap search base |
 | `akhq_ldap_group_enable`  | ""               | ldap group check |
 | `akhq_ldap_group_base`    | ""               | ldap group base |
+| `akhq_ldap_enabled`		| false			   | enable ldap authorization |
+| `java_bin`       			| /bin/java 	   | location of java; typically /bin/java or /usr/bin/java |
+| `akhq_listener_port` 		| 8081			   | port for the listener to use |
+| `akhq_listener_ssl`		| false			   | whether to enable SSL |
+| `akhq_listener_ssl_self_signed` | false      | whether to use a self-signed certificate for SSL |
 
 ## Examples
 
@@ -46,14 +54,27 @@ Recommanded role is geerlingguy.java
 	  roles:
 	    - role: ansible-apps_akhq
       vars:
+	  	# enable SSL
+	  	akhq_listener_port: 9443
+		akhq_listener_ssl: true
+		akhq_listener_ssl_self_signed: true
+		akhq_admin_passwd: myAdminPwd
+		akhq_reader_passwd: myReaderPwd
         suffix: ':9092'
         kafka_bootstrap_servers:
           - name: kafka_cluster
             servers: "{{ groups['kafka_cluster'] | product([suffix]) | map('join') | join(',') }}"
+			custom_properties:
+			  security.protocol: SSL
+			  ssl.truststore.location: /var/ssl/private/truststore.jks
+			  ssl.truststore.password: trustStorePwd
+			  ssl.keystore.location: /var/ssl/private/keystore.jks
+			  ssl.keystore.password: keyStorePwd
+			  ssl.key.password: KeyStorePwd
 	  environment: 
 	    http_proxy: "{{ http_proxy }}"
 	    https_proxy: "{{ https_proxy }}"
-	    no_proxy: "{{ no_proxy }}
+	    no_proxy: "{{ no_proxy }}"
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ Recommended role is geerlingguy.java
 | `akhq_ldap_enabled`       | false            | enable ldap authorization |
 | `akhq_listener_ssl`       | false            | whether to enable SSL |
 | `akhq_listener_ssl_self_signed` | false      | whether to use a self-signed certificate for SSL |
+| `akhq_keystore_filepath`  | ""               | file:/path/to/keystore.jks |
+| `akhq_keystore_password`  | ""               | password for the JKS keystore |
+| `akhq_keystore_type`      | PKCS12           | keystore type (JKS or PKCS12) |
+| `akhq_truststore_filepath` | ""              | file:/path/to/truststore.jks |
+| `akhq_truststore_password` | ""              | password for the JKS truststore |
+| `akhq_truststore_type`    | PKCS12           | truststore type (JKS or PKCS12) |
+| `akhq_jwt_secret`         | pleaseChangeThisSecretForANewOne | change this value for every deployment |
+| `akhq_prometheus_enabled` | rue             | whether to enable the prometheus metric exporter endpoint |
+| `akhq_endpoint_port`      | 9118             | port to expose the metric endpoint on |
+| `akhq_service_user`       | akhq             | user to run the service as |
+| `akhq_service_group`      | akhq             | group to assign to the service user |
 | `java_bin`                | /bin/java        | location of java; typically /bin/java or /usr/bin/java |
 | `lib_root_dir`            | /lib             | location of lib dir; typically /lib or /usr/lib |
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Recommended role is geerlingguy.java
 | `akhq_listener_ssl`		| false			   | whether to enable SSL |
 | `akhq_listener_ssl_self_signed` | false      | whether to use a self-signed certificate for SSL |
 | `java_bin`       			| /bin/java 	   | location of java; typically /bin/java or /usr/bin/java |
+| `lib_root_dir`			| /lib			   | location of lib dir; typically /lib or /usr/lib |
 
 ## Examples
 
@@ -65,12 +66,13 @@ Recommended role is geerlingguy.java
           - name: kafka_cluster
             servers: "{{ groups['kafka_cluster'] | product([suffix]) | map('join') | join(',') }}"
 			custom_properties:
+			  # Connect to an mTLS-secured cluster
 			  security.protocol: SSL
 			  ssl.truststore.location: /var/ssl/private/truststore.jks
 			  ssl.truststore.password: trustStorePwd
 			  ssl.keystore.location: /var/ssl/private/keystore.jks
 			  ssl.keystore.password: keyStorePwd
-			  ssl.key.password: KeyStorePwd
+			  ssl.key.password: keyStorePwd
 	  environment: 
 	    http_proxy: "{{ http_proxy }}"
 	    https_proxy: "{{ https_proxy }}"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ Recommended role is geerlingguy.java
 | `akhq_ldap_group_enable`  | ""               | ldap group check |
 | `akhq_ldap_group_base`    | ""               | ldap group base |
 | `akhq_ldap_enabled`		| false			   | enable ldap authorization |
-| `akhq_listener_port` 		| 8081			   | port for the listener to use |
 | `akhq_listener_ssl`		| false			   | whether to enable SSL |
 | `akhq_listener_ssl_self_signed` | false      | whether to use a self-signed certificate for SSL |
 | `java_bin`       			| /bin/java 	   | location of java; typically /bin/java or /usr/bin/java |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Recommended role is geerlingguy.java
 	    - role: ansible-apps_akhq
       vars:
 	  	# enable SSL
-	  	akhq_listener_port: 9443
 		akhq_listener_ssl: true
 		akhq_listener_ssl_self_signed: true
 		akhq_admin_passwd: myAdminPwd

--- a/README.md
+++ b/README.md
@@ -38,16 +38,16 @@ Recommended role is geerlingguy.java
 | `akhq_ldap_search_base`   | ""               | ldap search base |
 | `akhq_ldap_group_enable`  | ""               | ldap group check |
 | `akhq_ldap_group_base`    | ""               | ldap group base |
-| `akhq_ldap_enabled`		| false			   | enable ldap authorization |
-| `akhq_listener_ssl`		| false			   | whether to enable SSL |
+| `akhq_ldap_enabled`       | false            | enable ldap authorization |
+| `akhq_listener_ssl`       | false            | whether to enable SSL |
 | `akhq_listener_ssl_self_signed` | false      | whether to use a self-signed certificate for SSL |
-| `java_bin`       			| /bin/java 	   | location of java; typically /bin/java or /usr/bin/java |
-| `lib_root_dir`			| /lib			   | location of lib dir; typically /lib or /usr/lib |
+| `java_bin`                | /bin/java        | location of java; typically /bin/java or /usr/bin/java |
+| `lib_root_dir`            | /lib             | location of lib dir; typically /lib or /usr/lib |
 
 ## Examples
 
-	---
-	- hosts: apps_akhq
+    ---
+    - hosts: apps_akhq
       become: yes
       become_method: sudo
       gather_facts: yes

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Recommended role is geerlingguy.java
 | `akhq_ldap_group_enable`  | ""               | ldap group check |
 | `akhq_ldap_group_base`    | ""               | ldap group base |
 | `akhq_ldap_enabled`		| false			   | enable ldap authorization |
-| `java_bin`       			| /bin/java 	   | location of java; typically /bin/java or /usr/bin/java |
 | `akhq_listener_port` 		| 8081			   | port for the listener to use |
 | `akhq_listener_ssl`		| false			   | whether to enable SSL |
 | `akhq_listener_ssl_self_signed` | false      | whether to use a self-signed certificate for SSL |
+| `java_bin`       			| /bin/java 	   | location of java; typically /bin/java or /usr/bin/java |
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Recommended role is geerlingguy.java
 
 | Name                      | Default Value    | Description                        |
 | ------------------------- | ---------------- | -----------------------------------|
-| `akhq_version`            | 0.15.0           | akhq version |
+| `akhq_version`            | 0.17.0           | akhq version |
 | `akhq_install_dir`        | /opt/akhq        | Installation path for jar file |
 | `akhq_config_dir`         | /etc/akhq        | Configuration path for application |
 | `akhq_jar_file`           | akhq.jar         | Name of the jar file |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,7 +11,7 @@ lib_root_dir: "/lib"  # alternatively, /usr/lib
 
 # Configuration
 akhq_admin_passwd: "securepasswd"
-akhq_reader_password: "readonlypasswd"
+akhq_reader_password: "readpasswd"
 
 akhq_listener_port: 8081
 akhq_listener_ssl: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,8 +13,23 @@ lib_root_dir: "/lib"  # alternatively, /usr/lib
 akhq_admin_passwd: "securepasswd"
 akhq_reader_password: "readpasswd"
 
+akhq_service_user: akhq
+akhq_service_group: akhq
+
 akhq_listener_ssl: false
 akhq_listener_ssl_self_signed: false
+
+akhq_keystore_filepath: ""
+akhq_keystore_password: ""
+akhq_keystore_type: PKCS12 # JKS or PKCS12
+akhq_truststore_filepath: ""
+akhq_truststore_password: ""
+akhq_truststore_type: PKCS12 # JKS or PKCS12
+
+akhq_jwt_secret: "pleaseChangeThisSecretForANewOne"
+
+akhq_prometheus_enabled: true
+akhq_endpoint_port: 9118
 
 kafka_bootstrap_servers:
   - name: cluster1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,6 @@ lib_root_dir: "/lib"  # alternatively, /usr/lib
 akhq_admin_passwd: "securepasswd"
 akhq_reader_password: "readpasswd"
 
-akhq_listener_port: 8081
 akhq_listener_ssl: false
 akhq_listener_ssl_self_signed: false
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,18 +1,38 @@
 ---
 # Install
-akhq_version: "0.15.0"
+akhq_version: "0.17.0"
 akhq_jar_url: "https://github.com/tchiotludo/akhq/releases/download/{{ akhq_version }}/akhq.jar"
 akhq_install_dir: "/opt/akhq"
+akhq_config_dir: "/etc/akhq"
+akhq_jar_file: "akhq.jar"
+
+java_bin: "/bin/java" # alternatively, /usr/bin/java
+lib_root_dir: "/lib"  # alternatively, /usr/lib
 
 # Configuration
 akhq_admin_passwd: "securepasswd"
+akhq_reader_password: "readonlypasswd"
+
+akhq_listener_port: 8081
+akhq_listener_ssl: false
+akhq_listener_ssl_self_signed: false
+
 kafka_bootstrap_servers:
   - name: cluster1
-    servers: test1-01.prod.exemple.net:9092,test1-02.prod.exemple.net:9092
+    servers: test1-01.prod.example.net:9092,test1-02.prod.example.net:9092
+    # add custom configuration properties here, for each cluster connection
+    custom_properties:
+      #security.protocol: SSL
+      #ssl.truststore.location: /app/truststore.jks
+      #ssl.truststore.password: password
+      #ssl.keystore.location: /app/keystore.jks
+      #ssl.keystore.password: password
+      #ssl.key.password: password
 
-akhq_ldap_server: "ldap://ldap.exemple.neti:389"
-akhq_ldap_bindn: "uid=readonly,cn=users,cn=accounts,dc=exemple,dc=net"
+akhq_ldap_server: "ldap://ldap.example.net:389"
+akhq_ldap_bindn: "uid=readonly,cn=users,cn=accounts,dc=example,dc=net"
 akhq_ldap_bindpwd: "readonly_passwd"
-akhq_ldap_search_base: "cn=users,cn=accounts,dc=kexemple,dc=net"
+akhq_ldap_search_base: "cn=users,cn=accounts,dc=kexample,dc=net"
 akhq_ldap_group_enable: false
-akhq_ldap_group_base: "cn=groups,cn=accounts,dc=exemple,dc=net"
+akhq_ldap_group_base: "cn=groups,cn=accounts,dc=example,dc=net"
+akhq_ldap_enabled: false

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,6 +8,10 @@
       apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
       changed_when: false
+    - name: Update yum.
+      yum: update_cache=yes
+      when: ansible_os_family == 'RedHat'
+      changed_when: false
 
   roles:
     - role: geerlingguy.java

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,10 +8,6 @@
       apt: update_cache=yes cache_valid_time=600
       when: ansible_os_family == 'Debian'
       changed_when: false
-    - name: Update yum.
-      yum: update_cache=yes
-      when: ansible_os_family == 'RedHat'
-      changed_when: false
 
   roles:
     - role: geerlingguy.java

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,14 +55,14 @@
 - name: "Create config file for akhq"
   template:
     src: akhq.yml.j2
-    dest: {{ akhq_config_dir }}/akhq.yml
+    dest: "{{ akhq_config_dir }}/akhq.yml"
     mode: 0644
   notify: "restart akhq"
 
 - name: "Create systemd init for akhq"
   template:
     src: akhq.service
-    dest: {{ lib_root_dir }}/systemd/system/
+    dest: "{{ lib_root_dir }}/systemd/system"
     mode: 0644
   notify: "restart akhq"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "Check for akhq jar file"
   stat:
-    path: "{{ akhq_install_dir }}/akhq.jar"
+    path: "{{ akhq_install_dir }}/{{ akhq_jar_file }}"
   changed_when: false
   register: akhq_jar
 
@@ -15,41 +15,54 @@
 
     - name: "Ensure configuration directory exists"
       file:
-        path: '/etc/akhq/'
+        path: '{{ akhq_config_dir }}'
         state: directory
         mode: '0755'
 
     - name: "Download akhq jar file..."
       get_url:
         url: '{{ akhq_jar_url }}'
-        dest: "{{ akhq_install_dir }}/akhq.jar"
+        dest: "{{ akhq_install_dir }}/{{ akhq_jar_file }}"
         timeout: 120
         mode: 0644
 
-- name: "Convert passwd with sha256"
+- name: "Convert admin passwd with sha256"
   shell: |
     set -o pipefail
     echo -n "{{ akhq_admin_passwd }}" | sha256sum
   args:
     executable: /bin/bash
-  register: akhq_pwd
+  register: akhq_admin_pwd
   changed_when: false
 
 - name: "Set variable password converted with sha256"
   set_fact:
-    akhq_pwd_256: "{{ akhq_pwd.stdout.split(' ')[0] }}"
+    akhq_admin_pwd_256: "{{ akhq_admin_pwd.stdout.split(' ')[0] }}"
+
+- name: "Convert reader passwd with sha256"
+  shell: |
+    set -o pipefail
+    echo -n "{{ akhq_reader_passwd }}" | sha256sum
+  args:
+    executable: /bin/bash
+  register: akhq_reader_pwd
+  changed_when: false
+
+- name: "Set variable password converted with sha256"
+  set_fact:
+    akhq_reader_pwd_256: "{{ akhq_reader_pwd.stdout.split(' ')[0] }}"
 
 - name: "Create config file for akhq"
   template:
     src: akhq.yml.j2
-    dest: /etc/akhq/akhq.yml
+    dest: {{ akhq_config_dir }}/akhq.yml
     mode: 0644
   notify: "restart akhq"
 
 - name: "Create systemd init for akhq"
   template:
     src: akhq.service
-    dest: /lib/systemd/system/
+    dest: {{ lib_root_dir }}/systemd/system/
     mode: 0644
   notify: "restart akhq"
 

--- a/templates/akhq.service
+++ b/templates/akhq.service
@@ -5,6 +5,8 @@ Description=Manage Java service
 WorkingDirectory={{ akhq_install_dir }}
 ExecStart={{ java_bin }} -Dmicronaut.config.files={{ akhq_config_dir }}/akhq.yml -jar {{ akhq_jar_file }}
 Type=simple
+User={{ akhq_service_user }}
+Group={{ akhq_service_group }}
 Restart=on-failure
 RestartSec=10
 SuccessExitStatus=143

--- a/templates/akhq.service
+++ b/templates/akhq.service
@@ -3,7 +3,7 @@ Description=Manage Java service
 
 [Service]
 WorkingDirectory={{ akhq_install_dir }}
-ExecStart=/bin/java -Dmicronaut.config.files=/etc/akhq/akhq.yml -jar akhq.jar
+ExecStart={{ java_bin }} -Dmicronaut.config.files={{ akhq_config_dir }}/akhq.yml -jar {{ akhq_jar_file }}
 Type=simple
 Restart=on-failure
 RestartSec=10

--- a/templates/akhq.yml.j2
+++ b/templates/akhq.yml.j2
@@ -7,8 +7,24 @@ akhq:
 {% for key, val in cluster.custom_properties.items() %}
         {{ key }}: {{ val }}
 {% endfor %}
-
 {% endfor %}
+
+  # Auth & Roles
+  security:
+    default-group: no-roles # Forces login
+
+    # Basic auth configuration
+    basic-auth:
+      - username: admin
+        password: "{{ akhq_admin_pwd_256 }}"
+        passwordHash: SHA256
+        groups:
+        - admin
+      - username: reader
+        password: "{{ akhq_reader_pwd_256 }}"
+        passwordHash: SHA256
+        groups:
+        - reader
 
   server:
     base-path: "" # if behind a reverse proxy, path to akhq without trailing slash (optional). Example: akhq is
@@ -26,27 +42,10 @@ akhq:
     size: 50 # max record per page (default: 50)
     poll-timeout: 1000 # The time, in milliseconds, spent waiting in poll if data is not available in the buffer.
 
-  # Auth & Roles (optional)
-  security:
-    default-group: topic-reader # Default groups for all the user even unlogged user
-
-    # Basic auth configuration
-    basic-auth:
-      - username: admin
-        password: "{{ akhq_admin_pwd_256 }}" 
-        passwordHash: SHA256
-        groups: 
-        - admin
-      - username: reader
-        password: "{{ akhq_admin_pwd_256 }}"
-        passwordHash: SHA256
-        groups: 
-        - reader
-
-
 
 micronaut:
   security:
+    enabled: true
     # Ldap authentificaton configuration
     ldap:
       default:
@@ -60,12 +59,12 @@ micronaut:
         groups:
           enabled: {{ akhq_ldap_group_enable }}
           base: "{{ akhq_ldap_group_base }}"
-    # SSL endpoint configuration
-    ssl:
-      enabled: {{ akhq_listener_ssl }}
-      buildSelfSigned: {{ akhq_listener_ssl_self_signed }}
-      port: {{ akhq_listener_port }}
-      protocol: TLSv1.2
+  # SSL endpoint configuration
+  ssl:
+    enabled: {{ akhq_listener_ssl }}
+    buildSelfSigned: {{ akhq_listener_ssl_self_signed }}
+    protocol: TLSv1.2
+
 
 #Prometheus metrics
 endpoints:

--- a/templates/akhq.yml.j2
+++ b/templates/akhq.yml.j2
@@ -4,6 +4,10 @@ akhq:
     {{ cluster.name }}:
       properties:
         bootstrap.servers: "{{ cluster.servers }}"
+{% for key, val in cluster.custom_properties.items() %}
+        {{ key }}: {{ val }}
+{% endfor %}
+
 {% endfor %}
 
   server:
@@ -25,49 +29,19 @@ akhq:
   # Auth & Roles (optional)
   security:
     default-group: topic-reader # Default groups for all the user even unlogged user
-    # Groups definition
-    groups:
-      admin: # Group name
-        roles:  # roles for the group
-          - topic/read
-          - topic/insert
-          - topic/delete
-          - topic/config/update
-          - node/read
-          - node/config/update
-          - topic/data/read
-          - topic/data/insert
-          - topic/data/delete
-          - group/read
-          - group/delete
-          - group/offsets/update
-          - registry/read
-          - registry/insert
-          - registry/update
-          - registry/delete
-          - registry/version/delete
-          - acls/read
-          - connect/read
-          - connect/insert
-          - connect/update
-          - connect/delete
-          - connect/state/update
-#        attributes:
-#          # Regexp to filter topic available for group
-#          topics-filter-regexp: "test.*"
-      topic-reader: # Other group
-        roles:
-          - topic/read
-#        attributes:
-#          topics-filter-regexp: "test\\.reader.*"
 
     # Basic auth configuration
     basic-auth:
-      admin: # Username
-        password: "{{ akhq_pwd_256 }}" # Password in sha256sum
-        groups: # Groups for the user
-          - admin
-          - topic-reader
+      - username: admin
+        password: "{{ akhq_admin_pwd_256 }}" 
+        passwordHash: SHA256
+        groups: 
+        - admin
+      - username: reader
+        password: "{{ akhq_admin_pwd_256 }}"
+        passwordHash: SHA256
+        groups: 
+        - reader
 
 
 
@@ -76,7 +50,7 @@ micronaut:
     # Ldap authentificaton configuration
     ldap:
       default:
-        enabled: true
+        enabled: {{ akhq_ldap_enabled }}
         context:
           server: '{{ akhq_ldap_server }}'
           managerDn: '{{ akhq_ldap_bindn }}'
@@ -86,7 +60,12 @@ micronaut:
         groups:
           enabled: {{ akhq_ldap_group_enable }}
           base: "{{ akhq_ldap_group_base }}"
-
+    # SSL endpoint configuration
+    ssl:
+      enabled: {{ akhq_listener_ssl }}
+      buildSelfSigned: {{ akhq_listener_ssl_self_signed }}
+      port: {{ akhq_listener_port }}
+      protocol: TLSv1.2
 
 #Prometheus metrics
 endpoints:

--- a/templates/akhq.yml.j2
+++ b/templates/akhq.yml.j2
@@ -46,6 +46,14 @@ akhq:
 micronaut:
   security:
     enabled: true
+    token:
+      jwt:
+        enabled: true
+        signatures:
+          secret:
+            generator:
+              secret: {{ akhq_jwt_secret }}
+              jws-algorithm: HS256
     # Ldap authentificaton configuration
     ldap:
       default:
@@ -64,18 +72,35 @@ micronaut:
     enabled: {{ akhq_listener_ssl }}
     buildSelfSigned: {{ akhq_listener_ssl_self_signed }}
     protocol: TLSv1.2
+    keyStore:
+      path: {{ akhq_keystore_filepath }}
+      password: {{ akhq_keystore_password }}
+      type: {{ akhq_truststore_type }}
+    trustStore:
+      path: {{ akhq_truststore_filepath }}
+      password: {{ akhq_truststore_password }}
+      type: {{ akhq_truststore_type }}
+  #Prometheus metrics
+{% if akhq_prometheus_enabled %}
+  metrics:
+    enabled: true
+    export:
+      prometheus:
+        enabled: true
+        step: PT1M
+        descriptions: true
 
 
-#Prometheus metrics
 endpoints:
   all:
-    port: 9118
+    port: {{ akhq_endpoint_port }}
     enabled: true
     sensitive: false
   health:
     details-visible: ANONYMOUS
   loggers:
     write-sensitive: false
+{% endif %}
 
 
 #  connections:


### PR DESCRIPTION
1. Parameterize configuration paths and tasks.
2. Update configuration template to use custom_properties per connection.
3. Allow SSL to be enabled.
4. Removed explicit group configuration, using admin and reader default/built-in roles.
5. Force login, add reader login and password.
6. Update docs with new variables.
7. Enable security, but disable ldap and ssl by default.
8. Update default version of AKHQ.
9. Expose JWT token for configuration.
10. Parameterize metric port and Prometheus configuration.
11. Run service as a specific user and group.

Role tested and works on CentOS 7 and Ubuntu 20.04.